### PR TITLE
Change log level to debug

### DIFF
--- a/src/main/java/com/lulan/shincolle/server/ShinWorldData.java
+++ b/src/main/java/com/lulan/shincolle/server/ShinWorldData.java
@@ -91,7 +91,7 @@ public class ShinWorldData extends WorldSavedData
 	    if (map1 != null)
 	    {
 	    	NBTTagList tagList = new NBTTagList();
-			LogHelper.info("INFO: save world data: save unattackable target list: size: "+map1.size());
+			LogHelper.debug("DEBUG: save world data: save unattackable target list: size: "+map1.size());
 			
 			map1.forEach((key, str) ->
 			{


### PR DESCRIPTION
不知道是哪一個 mod 會不斷觸發儲存
導致下列訊息會不斷被輸出
`[Server thread/INFO] [Shinkeiseikan Collection/]: INFO: save world data: save unattackable target list: size: 0`
結果就變這樣
![](http://i.imgur.com/9ji6XcX.png)

不過我想同一個 method 裡其他 LogHelper 都是使用 debug level 的  
所以我想這個應該也可以設定成 debug level 吧

